### PR TITLE
Make rexical a development dependency

### DIFF
--- a/gherkin-ruby.gemspec
+++ b/gherkin-ruby.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "gherkin-ruby"
 
-  s.add_runtime_dependency 'rexical'
+  s.add_development_dependency 'rexical'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'racc'
 


### PR DESCRIPTION
Rexical is only used when compiling the lexer and not at runtime since
rexical generates code that depends on racc/parser, which is bundled with
Ruby stdlib.

This change adjust the gem specification dependency from runtime to
development.

Thank you! :heart:
