### PR TITLE
Store feature description

### DIFF
--- a/lib/gherkin/ast.rb
+++ b/lib/gherkin/ast.rb
@@ -16,6 +16,7 @@ module Gherkin
     class Feature < Node
       attr_reader :name, :background, :scenarios, :tags
       attr_writer :background, :scenarios, :tags
+      attr_accessor :description
 
       include Enumerable
 

--- a/lib/gherkin/parser/gherkin.y
+++ b/lib/gherkin/parser/gherkin.y
@@ -40,7 +40,7 @@ rule
     FeatureName           { result = val[0] }
   | FeatureName Newline   { result = val[0] }
   | FeatureName Newline
-      Description         { result = val[0] }
+      Description         { result = val[0]; result.description = val[2] }
   ;
 
   FeatureName:
@@ -49,8 +49,8 @@ rule
   ;
 
   Description:
-    TEXT Newline
-  | Description TEXT Newline
+    TEXT Newline             { result = val[0] }
+  | Description TEXT Newline { result = val[0...-1].flatten }
   ;
 
   Background:

--- a/lib/gherkin/parser/parser.rb
+++ b/lib/gherkin/parser/parser.rb
@@ -96,8 +96,8 @@ racc_reduce_table = [
   3, 20, :_reduce_13,
   2, 22, :_reduce_14,
   3, 22, :_reduce_15,
-  2, 23, :_reduce_none,
-  3, 23, :_reduce_none,
+  2, 23, :_reduce_16,
+  3, 23, :_reduce_17,
   2, 21, :_reduce_18,
   2, 24, :_reduce_19,
   1, 25, :_reduce_20,
@@ -268,7 +268,7 @@ module_eval(<<'.,.,', 'gherkin.y', 40)
 
 module_eval(<<'.,.,', 'gherkin.y', 42)
   def _reduce_13(val, _values, result)
-     result = val[0] 
+     result = val[0]; result.description = val[2] 
     result
   end
 .,.,
@@ -287,9 +287,19 @@ module_eval(<<'.,.,', 'gherkin.y', 47)
   end
 .,.,
 
-# reduce 16 omitted
+module_eval(<<'.,.,', 'gherkin.y', 51)
+  def _reduce_16(val, _values, result)
+     result = val[0] 
+    result
+  end
+.,.,
 
-# reduce 17 omitted
+module_eval(<<'.,.,', 'gherkin.y', 52)
+  def _reduce_17(val, _values, result)
+     result = val[0...-1].flatten 
+    result
+  end
+.,.,
 
 module_eval(<<'.,.,', 'gherkin.y', 57)
   def _reduce_18(val, _values, result)

--- a/test/gherkin/parser_test.rb
+++ b/test/gherkin/parser_test.rb
@@ -32,6 +32,10 @@ module Gherkin
     it 'generates a nice tree' do
       @result.must_be_kind_of AST::Feature
       @result.line.must_equal 1
+      @result.description.must_equal [
+        "In order to do something",
+        "As a developer",
+        "I want to be happy"]
 
       background = @result.background
       background.must_be_kind_of AST::Background


### PR DESCRIPTION
In order for better formatters in Spinach to work
we need to store metadata like the feature description
so spinach formatters can retreive it and output it
